### PR TITLE
Update max base to 1.1.3 and bump version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codait/max-base:v1.1.1
+FROM codait/max-base:v1.1.3
 
 ARG model_bucket=http://max-assets.s3.us.cloud-object-storage.appdomain.cloud/max-image-resolution-enhancer/1.0
 ARG model_file=assets.tar.gz

--- a/config.py
+++ b/config.py
@@ -8,7 +8,7 @@ SWAGGER_UI_DOC_EXPANSION = 'none'
 # API metadata
 API_TITLE = 'MAX Image Resolution Enhancer'
 API_DESC = 'Upscale low-resolution images by a factor of 4. This model was trained on the OpenImagesV4 dataset.'
-API_VERSION = '1.0.0'
+API_VERSION = '1.0.1'
 
 # default model
 MODEL_NAME = 'SRGAN'


### PR DESCRIPTION
Updating MAX base to 1.1.3 to patch the CORS issue and bump the version number accordingly.